### PR TITLE
Alteração na ordem da assertiva

### DIFF
--- a/TRAB2-3/PECAS.C
+++ b/TRAB2-3/PECAS.C
@@ -51,14 +51,14 @@ typedef struct Peca {
 
 PEC_CondRet PEC_CriaPeca ( PEC_Peca ** pPeca, int ind, int cor ) 
 {
-	if(pPeca[ind]!=NULL)
-	{
-		return PEC_CondRetJaExiste;
-	}
-
 	if ( cor < 0 || cor > 3 )
 	{
 		return PEC_CondRetCorInvalida ;
+	}
+
+	if(pPeca[ind]!=NULL)
+	{
+		return PEC_CondRetJaExiste;
 	}
 
 	pPeca[ind] = ( PEC_Peca * ) malloc ( sizeof ( PEC_Peca ) ) ;

--- a/TRAB2-3/PECAS.C
+++ b/TRAB2-3/PECAS.C
@@ -56,6 +56,11 @@ PEC_CondRet PEC_CriaPeca ( PEC_Peca ** pPeca, int ind, int cor )
 		return PEC_CondRetJaExiste;
 	}
 
+	if ( cor < 0 || cor > 3 )
+	{
+		return PEC_CondRetCorInvalida ;
+	}
+
 	pPeca[ind] = ( PEC_Peca * ) malloc ( sizeof ( PEC_Peca ) ) ;
 
 	if ( pPeca[ind] == NULL ) 
@@ -63,10 +68,7 @@ PEC_CondRet PEC_CriaPeca ( PEC_Peca ** pPeca, int ind, int cor )
 		return PEC_CondRetFaltaMemoria ;
 	}
 
-	if ( cor < 0 || cor > 3 )
-	{
-		return PEC_CondRetCorInvalida ;
-	}
+	
 
 	pPeca[ind]->cor    = cor ;
 	pPeca[ind]->final  = 0   ;


### PR DESCRIPTION
Alteração na função CriaPeça:
A assertiva que confere a cor da peça estava sendo feita após a alocação. Dessa maneira, a alocação seria feita mesmo que a função chamadora mandasse a cor errada. Assim, se a função chama CriaPeça com a cor incorreta, e depois chama com a cor correta irá retornar PEC_CondRetJaExiste, sabendo que na primeira vez foi alocado incorretamente. 